### PR TITLE
World Forge licenses

### DIFF
--- a/plugins/001_Alphean's Random Expansion/data/world forge add on
+++ b/plugins/001_Alphean's Random Expansion/data/world forge add on
@@ -181,3 +181,28 @@ planet Forge
 planet Human
 	outfitter "AE Human"
 	shipyard "AE Human"
+
+outfit "Alr Military License"
+	category Special
+	cost 50000
+	thumbnail outfit/license
+
+outfit "Alr Mixed License"
+	category Special
+	cost 50000
+	thumbnail outfit/license
+
+outfit "Alr Civilian License"
+	category Special
+	cost 50000
+	thumbnail outfit/license
+
+outfit "Terror of the Galaxy License"
+	category Special
+	cost 50000
+	thumbnail outfit/license
+
+outfit "Tarazed License"
+	category Special
+	cost 50000
+	thumbnail outfit/license

--- a/plugins/001_Alphean's Random Expansion/data/world forge add on
+++ b/plugins/001_Alphean's Random Expansion/data/world forge add on
@@ -206,3 +206,10 @@ outfit "Tarazed License"
 	category Special
 	cost 50000
 	thumbnail outfit/license
+
+outfitter licenses
+	"Tarazed License"
+	"Terror of the Galaxy License"
+	"Alr Civilian License"
+	"Alr Mixed License"
+	"Alr Military License"


### PR DESCRIPTION
Allows the player to buy licenses instead of having to unlock them when World Forge is installed.
